### PR TITLE
test: remove Python 3.10 skip decorators

### DIFF
--- a/src/millie/cli/migrate/manager.py
+++ b/src/millie/cli/migrate/manager.py
@@ -123,20 +123,3 @@ def create(name: str):
     except Exception as e:
         echo(f"❌ Error creating migration: {str(e)}", err=True)
         sys.exit(1)
-
-# @migrate.command()
-# def run():
-#     """Run all pending migrations."""
-#     try:
-#         from ..schema.migration_manager import MigrationManager
-#         from ..config.rag_config import RAGConfig
-
-#         config = RAGConfig()
-#         manager = MigrationManager(config)
-#         manager.run_migrations()
-#         echo("✅ Successfully ran migrations")
-#     except Exception as e:
-#         echo(f"❌ Error running migrations: {str(e)}", err=True)
-#         sys.exit(1)
-
-

--- a/tests/cli/test_attu.py
+++ b/tests/cli/test_attu.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 from millie.cli import cli, add_millie_commands
 from millie.cli.attu.manager import attu
 from tests.cli.docker_mock import DockerCommandMock, MockResponse
-from tests.util import click_skip_py310
 
 @pytest.fixture
 def test_cli():
@@ -37,7 +36,6 @@ def mock_sleep(monkeypatch):
         pass
     monkeypatch.setattr("time.sleep", mock_sleep)
 
-@click_skip_py310()
 def test_start_command_milvus_not_running(test_cli, cli_runner, mock_docker_command):
     """Test starting Attu when Milvus is not running."""
     mock_docker_command.set_responses({
@@ -51,7 +49,6 @@ def test_start_command_milvus_not_running(test_cli, cli_runner, mock_docker_comm
     assert result.exit_code == 1
     assert "❌ Milvus must be running" in result.output
 
-@click_skip_py310()
 def test_start_command_container_exists(test_cli, cli_runner, mock_docker_command):
     """Test starting Attu when container exists."""
     mock_docker_command.set_responses({
@@ -75,7 +72,6 @@ def test_start_command_container_exists(test_cli, cli_runner, mock_docker_comman
     assert result.exit_code == 0
     assert "✅ Attu container started!" in result.output
 
-@click_skip_py310()
 def test_start_command_container_stopped(test_cli, cli_runner, mock_docker_command):
     """Test starting Attu when container is stopped."""
     mock_docker_command.set_responses({
@@ -99,7 +95,6 @@ def test_start_command_container_stopped(test_cli, cli_runner, mock_docker_comma
     assert result.exit_code == 0
     assert "✅ Attu container started!" in result.output
 
-@click_skip_py310()
 def test_start_command_new_container(test_cli, cli_runner, mock_docker_command):
     """Test starting Attu with a new container."""
     mock_docker_command.set_responses({
@@ -123,7 +118,6 @@ def test_start_command_new_container(test_cli, cli_runner, mock_docker_command):
     assert result.exit_code == 0
     assert "✅ Attu container started!" in result.output
 
-@click_skip_py310()
 def test_stop_command_success(test_cli, cli_runner, mock_docker_command):
     """Test stopping Attu successfully."""
     mock_docker_command.set_responses({
@@ -142,7 +136,6 @@ def test_stop_command_success(test_cli, cli_runner, mock_docker_command):
     assert result.exit_code == 0
     assert "✅ Attu container stopped!" in result.output
 
-@click_skip_py310()
 def test_status_command_running(test_cli, cli_runner, mock_docker_command):
     """Test status command when container is running."""
     mock_docker_command.set_responses({
@@ -156,7 +149,6 @@ def test_status_command_running(test_cli, cli_runner, mock_docker_command):
     assert result.exit_code == 0
     assert "✅ Attu container is running!" in result.output
 
-@click_skip_py310()
 def test_status_command_not_running(test_cli, cli_runner, mock_docker_command):
     """Test status command when container is not running."""
     mock_docker_command.set_responses({

--- a/tests/cli/test_milvus.py
+++ b/tests/cli/test_milvus.py
@@ -50,7 +50,7 @@ def mock_env_vars(monkeypatch):
     monkeypatch.setenv("MILVUS_PORT", "19530")
     monkeypatch.setenv("MILVUS_VERSION", "2.3.3")
 
-@click_skip_py310()
+
 def test_start_command_docker_not_running(test_cli, cli_runner, mock_docker_command):
     """Test start command when Docker is not running."""
     mock_docker_command.set_responses({
@@ -65,7 +65,7 @@ def test_start_command_docker_not_running(test_cli, cli_runner, mock_docker_comm
     assert result.exit_code == 1
     assert "Docker is not running" in result.output
 
-@click_skip_py310()
+
 def test_start_command_container_exists(test_cli, cli_runner, mock_docker_command):
     """Test starting Milvus when container exists and is running."""
     mock_docker_command.set_responses({
@@ -87,7 +87,7 @@ def test_start_command_container_exists(test_cli, cli_runner, mock_docker_comman
     assert result.exit_code == 0
     assert "✅ Milvus container is already running!" in result.output
 
-@click_skip_py310()
+
 def test_start_command_container_stopped(test_cli, cli_runner, mock_docker_command):
     """Test starting Milvus when container is stopped."""
     mock_docker_command.set_responses({
@@ -116,7 +116,7 @@ def test_start_command_container_stopped(test_cli, cli_runner, mock_docker_comma
     assert "Starting existing Milvus container..." in result.output
     assert "✅ Milvus container started!" in result.output
 
-@click_skip_py310()
+
 def test_start_command_new_container(test_cli, cli_runner, mock_docker_command, mock_sleep):
     
     """Test starting Milvus with a new container."""
@@ -164,7 +164,7 @@ def test_start_command_new_container(test_cli, cli_runner, mock_docker_command, 
     assert "Starting Milvus in standalone mode..." in result.output
     assert "✅ Milvus container started!" in result.output
 
-@click_skip_py310()
+
 def test_stop_command_success(test_cli, cli_runner, mock_docker_command):
     """Test stopping Milvus successfully."""
     mock_docker_command.set_responses({
@@ -186,7 +186,7 @@ def test_stop_command_success(test_cli, cli_runner, mock_docker_command):
     assert result.exit_code == 0
     assert "✅ Milvus container stopped!" in result.output
 
-@click_skip_py310()
+
 def test_status_command_running(test_cli, cli_runner, mock_docker_command):
     """Test checking Milvus status when running."""
     mock_docker_command.set_responses({
@@ -202,7 +202,7 @@ def test_status_command_running(test_cli, cli_runner, mock_docker_command):
     assert result.exit_code == 0
     assert "✅ Milvus container is running!" in result.output
 
-@click_skip_py310()
+
 def test_status_command_not_running(test_cli, cli_runner, mock_docker_command):
     """Test checking Milvus status when not running."""
     mock_docker_command.set_responses({


### PR DESCRIPTION
Clean up test files by removing unnecessary `@click_skip_py310()` decorators, likely related to previous Python version compatibility updates,